### PR TITLE
Relax platform string format

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -50,14 +50,9 @@ func Acquire(ctx context.Context, buildID, token, platform string) (*Machine, er
 		}
 	}()
 
-	var builderPlatform cliv1.BuilderPlatform
-	switch m.Platform {
-	case "amd64":
-		builderPlatform = cliv1.BuilderPlatform_BUILDER_PLATFORM_AMD64
-	case "arm64":
+	builderPlatform := cliv1.BuilderPlatform_BUILDER_PLATFORM_AMD64
+	if strings.Contains(m.Platform, "arm") {
 		builderPlatform = cliv1.BuilderPlatform_BUILDER_PLATFORM_ARM64
-	default:
-		return nil, errors.Errorf("unsupported platform: %s", m.Platform)
 	}
 
 	client := api.NewBuildClient()

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -51,7 +51,7 @@ func Acquire(ctx context.Context, buildID, token, platform string) (*Machine, er
 	}()
 
 	builderPlatform := cliv1.BuilderPlatform_BUILDER_PLATFORM_AMD64
-	if strings.Contains(m.Platform, "arm") {
+	if strings.Contains(m.Platform, "arm") || strings.Contains(m.Platform, "aarch") {
 		builderPlatform = cliv1.BuilderPlatform_BUILDER_PLATFORM_ARM64
 	}
 


### PR DESCRIPTION
Updates so that all builds will use the Intel builders, unless the requested platform contains the string `arm` or `aarch`.